### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Potential fix for [https://github.com/SchoolOfFreelancing/Freelancing-On-Linux/security/code-scanning/1](https://github.com/SchoolOfFreelancing/Freelancing-On-Linux/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege access unless overridden. For this workflow, the minimal required permission is:

- `contents: read` (needed for repository checkout)

Best fix without changing behavior:
- Edit `.github/workflows/blank.yml`
- Insert a top-level `permissions:` section between the trigger block (`on:`...) and `jobs:`
- Set `contents: read`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
